### PR TITLE
Add license file and valid SPDX identifier to project settings

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,6 +5,8 @@ build-backend = "maturin"
 [project]
 name = "janitor-rs"
 requires-python = ">=3.8"
+license = "MIT"
+license-files = ["LICENSE"]
 classifiers = [
     "Programming Language :: Rust",
     "Programming Language :: Python :: Implementation :: CPython",


### PR DESCRIPTION
Fixes license specifiers according to https://packaging.python.org/en/latest/guides/writing-pyproject-toml/#license-and-license-files

This allows automatic license inspection tools like pip-licenses to correctly categorize this package.